### PR TITLE
radigo を 0.12.0 にアップデート

### DIFF
--- a/rec_radiko/Dockerfile
+++ b/rec_radiko/Dockerfile
@@ -8,7 +8,7 @@ RUN bundle install --path=vendor/bundle
 
 FROM amazon/aws-lambda-ruby:2.7 AS download
 WORKDIR /tmp
-ADD https://github.com/yyoshiki41/radigo/releases/download/v0.11.0/radigo_v0.11.0_linux_amd64.zip /tmp/radigo.zip
+ADD https://github.com/yyoshiki41/radigo/releases/download/v0.12.0/radigo_v0.12.0_linux_amd64.zip /tmp/radigo.zip
 ADD https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-amd64-static.tar.xz /tmp/ffmpeg.tar.xz
 RUN yum install -y unzip tar xz \
   && unzip /tmp/radigo.zip \


### PR DESCRIPTION
radiko の仕様変更により、エリアフリーの録音ができない状態となっていました。

radiko の仕様変更に対応した radigo がリリースされていたので、最新バージョン 0.12.0 にアップデートしたところ、問題なく録音できることを確認できました。