### PR TITLE
Use S3 Intelligent-Tiering storage class for episode uploads

### DIFF
--- a/rec_radiko/lib/rec-radiko/s3.rb
+++ b/rec_radiko/lib/rec-radiko/s3.rb
@@ -14,7 +14,7 @@ module Radicaster
       def save_episode(episode)
         key = make_key(episode)
         open(episode.local_path) do |f|
-          client.put_object(bucket: bucket, key: key, body: f)
+          client.put_object(bucket: bucket, key: key, body: f, storage_class: "INTELLIGENT_TIERING")
         end
       end
 

--- a/rec_radiko/spec/s3_spec.rb
+++ b/rec_radiko/spec/s3_spec.rb
@@ -50,6 +50,7 @@ module Radicaster::RecRadiko
         expect(client).to receive(:put_object).with(hash_including(
           bucket: bucket,
           key: "test/data/20210622.m4a",
+          storage_class: "INTELLIGENT_TIERING",
         ))
         s3.save_episode(episode)
       end


### PR DESCRIPTION
Add storage_class: "INTELLIGENT_TIERING" to put_object call in
rec-radiko Lambda so recorded episodes are stored with S3
Intelligent-Tiering, enabling automatic cost optimization based
on access patterns.

https://claude.ai/code/session_016qAyDmzz7vGLSUGTmEWoAi

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, isolated change to S3 upload options with a matching unit test update; risk mainly limited to unexpected storage-class behavior in the target bucket/account.
> 
> **Overview**
> Episode uploads to S3 now explicitly set `storage_class: "INTELLIGENT_TIERING"` in `S3#save_episode`, so newly recorded episode objects use S3 Intelligent-Tiering by default.
> 
> The `s3_spec` expectation is updated to assert the new `put_object` parameter.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 57c4b7f82bce63abade89d569dbd7ce8ac4c51c0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->