### PR TITLE
番組ごとの録音データ保持ポリシー設定を追加

### DIFF
--- a/cleanup_episodes/Dockerfile
+++ b/cleanup_episodes/Dockerfile
@@ -1,0 +1,17 @@
+FROM amazon/aws-lambda-ruby:2.7 AS bundler
+WORKDIR /var/task
+RUN yum groupinstall -y "Development Tools"
+COPY ./Gemfile ./Gemfile
+COPY ./Gemfile.lock ./Gemfile.lock
+RUN bundle install --path=vendor/bundle
+
+
+FROM amazon/aws-lambda-ruby:2.7
+WORKDIR /var/task
+
+ENV TZ=Asia/Tokyo
+
+COPY --from=bundler /var/task/vendor ./vendor
+COPY ./ ./
+
+CMD ["function.Handler.handle"]

--- a/cleanup_episodes/Gemfile
+++ b/cleanup_episodes/Gemfile
@@ -1,0 +1,10 @@
+source "https://rubygems.org"
+
+git_source(:github) do |repo_name|
+  repo_name = "#{repo_name}/#{repo_name}" unless repo_name.include?("/")
+  "https://github.com/#{repo_name}.git"
+end
+
+ruby "~> 2.7.0"
+
+gem "aws-sdk-s3"

--- a/cleanup_episodes/Gemfile.lock
+++ b/cleanup_episodes/Gemfile.lock
@@ -1,0 +1,32 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    aws-eventstream (1.1.1)
+    aws-partitions (1.432.0)
+    aws-sdk-core (3.112.1)
+      aws-eventstream (~> 1, >= 1.0.2)
+      aws-partitions (~> 1, >= 1.239.0)
+      aws-sigv4 (~> 1.1)
+      jmespath (~> 1.0)
+    aws-sdk-kms (1.42.0)
+      aws-sdk-core (~> 3, >= 3.112.0)
+      aws-sigv4 (~> 1.1)
+    aws-sdk-s3 (1.90.0)
+      aws-sdk-core (~> 3, >= 3.112.0)
+      aws-sdk-kms (~> 1)
+      aws-sigv4 (~> 1.1)
+    aws-sigv4 (1.2.3)
+      aws-eventstream (~> 1, >= 1.0.2)
+    jmespath (1.4.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  aws-sdk-s3
+
+RUBY VERSION
+   ruby 2.7.2p137
+
+BUNDLED WITH
+   2.1.4

--- a/cleanup_episodes/function.rb
+++ b/cleanup_episodes/function.rb
@@ -1,0 +1,13 @@
+$LOAD_PATH.unshift(File.dirname(__FILE__) + "/lib")
+
+require "logger"
+require "cleanup-episodes"
+require "aws-sdk-s3"
+
+logger = Logger.new(STDOUT)
+
+bucket = ENV["RADICASTER_S3_BUCKET"] or raise "ENV['RADICASTER_S3_BUCKET'] must be set"
+
+s3_client = Aws::S3::Client.new
+
+Handler = Radicaster::CleanupEpisodes::Handler.new(logger, s3_client, bucket)

--- a/cleanup_episodes/lib/cleanup-episodes.rb
+++ b/cleanup_episodes/lib/cleanup-episodes.rb
@@ -1,0 +1,1 @@
+require "cleanup-episodes/handler"

--- a/cleanup_episodes/lib/cleanup-episodes/handler.rb
+++ b/cleanup_episodes/lib/cleanup-episodes/handler.rb
@@ -1,0 +1,126 @@
+require "aws-sdk-s3"
+require "yaml"
+require "date"
+
+module Radicaster
+  module CleanupEpisodes
+    # m4aファイルアップロード時に発動し、保持ポリシーに基づいて古いエピソードを削除する
+    class Handler
+      EPISODE_EXT = ".m4a"
+      # ファイル名から日付を抽出する正規表現 (YYYYMMDD.m4a)
+      DATE_PATTERN = /(\d{8})\.m4a\z/
+
+      def initialize(logger, s3_client, bucket)
+        @logger = logger
+        @s3_client = s3_client
+        @bucket = bucket
+      end
+
+      def handle(event:, context:)
+        logger.info("Start cleanup episode handling.")
+        id = extract_id(event)
+        definition = load_definition(id)
+
+        unless definition
+          logger.info("Definition not found for id: #{id}. Skipping.")
+          return
+        end
+
+        retention_type = definition["retention_type"]
+        retention_value = definition["retention_value"]
+
+        unless retention_type && retention_value
+          logger.info("No retention policy set for id: #{id}. Skipping.")
+          return
+        end
+
+        case retention_type
+        when "count"
+          cleanup_by_count(id, retention_value.to_i)
+        when "days"
+          cleanup_by_days(id, retention_value.to_i)
+        else
+          logger.info("Unknown retention_type: #{retention_type}. Skipping.")
+        end
+
+        logger.info("Cleanup episode handling finished.")
+      end
+
+      private
+
+      attr_reader :logger, :s3_client, :bucket
+
+      def extract_id(event)
+        raise '"s3" is not contained in the event' unless event["Records"][0]["s3"]
+        key = event["Records"][0]["s3"]["object"]["key"]
+        logger.debug("S3 key: #{key}")
+        # key format: {id}/data/{YYYYMMDD}.m4a
+        key.split("/").first
+      end
+
+      def load_definition(id)
+        key = "radicaster/#{id}.yaml"
+        resp = s3_client.get_object(bucket: bucket, key: key)
+        YAML.load(resp.body.read)
+      rescue Aws::S3::Errors::NoSuchKey
+        nil
+      end
+
+      def list_episodes(id)
+        prefix = "#{id}/data/"
+        resp = s3_client.list_objects_v2(bucket: bucket, prefix: prefix)
+        return [] unless resp.contents
+
+        resp.contents
+          .select { |obj| obj.key.end_with?(EPISODE_EXT) }
+          .sort_by { |obj| obj.key }
+      end
+
+      def extract_date_from_key(key)
+        match = key.match(DATE_PATTERN)
+        return nil unless match
+        Date.strptime(match[1], "%Y%m%d")
+      rescue Date::Error
+        nil
+      end
+
+      def cleanup_by_count(id, keep_count)
+        episodes = list_episodes(id)
+        logger.info("Found #{episodes.size} episodes for id: #{id}, keeping last #{keep_count}")
+
+        return if episodes.size <= keep_count
+
+        # ファイル名(日付)でソートされているので、古い順に並んでいる
+        # 末尾のkeep_count個を残して、先頭の古いものを削除
+        to_delete = episodes[0..-(keep_count + 1)]
+
+        to_delete.each do |obj|
+          logger.info("Deleting old episode: #{obj.key}")
+          s3_client.delete_object(bucket: bucket, key: obj.key)
+        end
+
+        logger.info("Deleted #{to_delete.size} episodes for id: #{id}")
+      end
+
+      def cleanup_by_days(id, keep_days)
+        episodes = list_episodes(id)
+        cutoff_date = Date.today - keep_days
+        logger.info("Found #{episodes.size} episodes for id: #{id}, deleting before #{cutoff_date}")
+
+        deleted_count = 0
+        episodes.each do |obj|
+          episode_date = extract_date_from_key(obj.key)
+          next unless episode_date
+
+          if episode_date < cutoff_date
+            logger.info("Deleting old episode: #{obj.key} (date: #{episode_date})")
+            s3_client.delete_object(bucket: bucket, key: obj.key)
+            deleted_count += 1
+          end
+        end
+
+        logger.info("Deleted #{deleted_count} episodes for id: #{id}")
+      end
+    end
+  end
+end

--- a/deployment/lib/radicaster-stack.ts
+++ b/deployment/lib/radicaster-stack.ts
@@ -41,6 +41,7 @@ export class RadicasterStack extends cdk.Stack {
     const dist = this.setUpCloudFront(bucket, params);
     this.setUpFuncRecRadiko(bucket, params);
     this.setUpFuncGenFeed(bucket, dist, params);
+    this.setUpFuncCleanupEpisodes(bucket, params);
   }
 
   private setUpS3Bucket(params: Params) {
@@ -119,6 +120,36 @@ export class RadicasterStack extends cdk.Stack {
       }
     ));
     return funcGenFeed;
+  }
+
+  private setUpFuncCleanupEpisodes(bucket: Bucket, params: Params) {
+    const funcCleanup = new DockerImageFunction(this, `func-cleanup-episodes`, {
+      code: DockerImageCode.fromImageAsset(
+        "../cleanup_episodes"
+      ),
+      functionName: `radicaster-cleanup-episodes${params.suffix}`,
+      timeout: Duration.minutes(1),
+      memorySize: 128,
+      environment: {
+        "RADICASTER_S3_BUCKET": params.bucketName,
+      }
+    });
+    if (!funcCleanup.role) {
+      throw new Error("funcCleanup.role is undefined");
+    }
+    bucket.grantRead(funcCleanup.role);
+    bucket.grantDelete(funcCleanup.role);
+
+    funcCleanup.addEventSource(new S3EventSource(
+      bucket,
+      {
+        events: [EventType.OBJECT_CREATED],
+        filters: [{
+          suffix: ".m4a"
+        }],
+      }
+    ));
+    return funcCleanup;
   }
 
   private setUpCloudFront(bucket: Bucket, params: Params) {

--- a/web/app/api/recordings/[id]/route.ts
+++ b/web/app/api/recordings/[id]/route.ts
@@ -13,6 +13,8 @@ const requestSchema = z.object({
   duration: z.number().min(1),
   program_schedule: z.array(z.string().min(1)),
   execution_schedule: z.array(scheduleSchema),
+  retention_type: z.enum(["none", "count", "days"]).optional(),
+  retention_value: z.number().min(1).optional(),
 });
 
 export async function GET(

--- a/web/app/api/recordings/route.ts
+++ b/web/app/api/recordings/route.ts
@@ -20,6 +20,8 @@ const requestSchema = z.object({
   duration: z.number().min(1),
   program_schedule: z.array(z.string().min(1)),
   execution_schedule: z.array(scheduleSchema),
+  retention_type: z.enum(["none", "count", "days"]).optional(),
+  retention_value: z.number().min(1).optional(),
 });
 
 export async function GET() {

--- a/web/app/components/RecordingForm.tsx
+++ b/web/app/components/RecordingForm.tsx
@@ -27,7 +27,12 @@ const formSchema = z.object({
   area: z.string().min(1, "Area ID is required"),
   station: z.string().min(1, "Station ID is required"),
   schedules: z.array(scheduleItemSchema).min(1, "At least one schedule is required"),
-});
+  retentionType: z.enum(["none", "count", "days"]).default("none"),
+  retentionValue: z.number().min(1, "Must be at least 1").optional(),
+}).refine(
+  (data) => data.retentionType === "none" || (data.retentionValue !== undefined && data.retentionValue >= 1),
+  { message: "Retention value is required when retention type is set", path: ["retentionValue"] }
+);
 
 export type FormValues = z.infer<typeof formSchema>;
 
@@ -72,6 +77,8 @@ export function RecordingForm({ initialValues, isEditing = false, onSubmit, isSu
     area: DEFAULT_AREA_ID,
     station: "",
     schedules: [{ startDay: "Mon", startHour: "21", startMinute: "00", durationMinutes: undefined as any, offsetMinutes: 5 }],
+    retentionType: "none",
+    retentionValue: undefined,
     ...initialValues,
   };
 
@@ -227,6 +234,8 @@ export function RecordingForm({ initialValues, isEditing = false, onSubmit, isSu
         )}
       </div>
 
+      <RetentionSettings control={control} register={register} errors={errors} />
+
       <div className="pt-4 border-t border-gray-200">
         <button
           type="submit"
@@ -247,6 +256,61 @@ interface ScheduleRowProps {
   remove: () => void;
   canRemove: boolean;
   errors: FieldErrors<FormValues>;
+}
+
+interface RetentionSettingsProps {
+  control: Control<FormValues>;
+  register: UseFormRegister<FormValues>;
+  errors: FieldErrors<FormValues>;
+}
+
+function RetentionSettings({ control, register, errors }: RetentionSettingsProps) {
+  const retentionType = useWatch({ control, name: "retentionType" });
+
+  return (
+    <div className="p-4 border rounded-md bg-gray-50">
+      <label className="block text-sm font-medium text-gray-700 mb-1">Retention Policy</label>
+      <p className="text-xs text-gray-500 mb-3">保持ポリシー: 古い録音データの自動削除設定</p>
+      <div className="flex flex-col sm:flex-row gap-4 items-start sm:items-center">
+        <div className="w-full sm:w-48">
+          <label className="block text-xs font-medium text-gray-500 mb-1">Type</label>
+          <p className="text-[10px] text-gray-400 mb-1">削除条件の種類</p>
+          <select
+            {...register("retentionType")}
+            className="block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm p-2 border"
+          >
+            <option value="none">None (keep all)</option>
+            <option value="count">Keep last N episodes</option>
+            <option value="days">Keep last N days</option>
+          </select>
+        </div>
+
+        {retentionType !== "none" && (
+          <div className="w-full sm:w-36">
+            <label className="block text-xs font-medium text-gray-500 mb-1">
+              {retentionType === "count" ? "Episodes to keep" : "Days to keep"}
+            </label>
+            <p className="text-[10px] text-gray-400 mb-1">
+              {retentionType === "count" ? "保持する回数" : "保持する日数"}
+            </p>
+            <input
+              type="number"
+              min={1}
+              {...register("retentionValue", { valueAsNumber: true })}
+              className={cn(
+                "block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm p-2 border",
+                errors.retentionValue && "border-red-500"
+              )}
+              placeholder={retentionType === "count" ? "e.g. 10" : "e.g. 30"}
+            />
+            {errors.retentionValue && (
+              <p className="mt-1 text-xs text-red-600">{errors.retentionValue.message}</p>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
 }
 
 function ScheduleRow({ index, control, register, remove, canRemove, errors }: ScheduleRowProps) {

--- a/web/app/recordings/[id]/page.tsx
+++ b/web/app/recordings/[id]/page.tsx
@@ -117,6 +117,8 @@ export default function EditRecordingPage({ params }: { params: Promise<{ id: st
           area: yamlData.area || "",
           station: yamlData.station || "",
           schedules: schedules,
+          retentionType: yamlData.retention_type || "none",
+          retentionValue: yamlData.retention_value || undefined,
           // imageFile is skipped, user has to re-upload if they want
         });
 
@@ -135,7 +137,7 @@ export default function EditRecordingPage({ params }: { params: Promise<{ id: st
     const { imageFile, ...rest } = formData;
 
     // Recalculate execution times
-    const payload = {
+    const payload: Record<string, any> = {
       ...rest,
       id: id, // Ensure ID is from params, though form field is disabled
       program_schedule: formData.schedules.map(s => `${s.startDay} ${s.startHour}:${s.startMinute}`),
@@ -165,6 +167,10 @@ export default function EditRecordingPage({ params }: { params: Promise<{ id: st
         return `${newDay} ${newHour}:${newMinute}`;
       }),
     };
+    if (formData.retentionType && formData.retentionType !== "none") {
+      payload.retention_type = formData.retentionType;
+      payload.retention_value = formData.retentionValue;
+    }
 
     const apiFormData = new FormData();
     apiFormData.append("data", JSON.stringify(payload));

--- a/web/app/recordings/new/page.tsx
+++ b/web/app/recordings/new/page.tsx
@@ -40,12 +40,16 @@ export default function NewRecordingPage() {
     // Transform form data to API payload
     const { imageFile, ...rest } = data;
 
-    const payload = {
+    const payload: Record<string, any> = {
       ...rest,
       program_schedule: data.schedules.map(s => `${s.startDay} ${s.startHour}:${s.startMinute}`),
       duration: data.schedules[0]?.durationMinutes,
       execution_schedule: data.schedules.map(s => calculateExecutionTime(s.startDay, s.startHour, s.startMinute, s.durationMinutes, s.offsetMinutes)),
     };
+    if (data.retentionType && data.retentionType !== "none") {
+      payload.retention_type = data.retentionType;
+      payload.retention_value = data.retentionValue;
+    }
 
     const formData = new FormData();
     formData.append("data", JSON.stringify(payload));

--- a/web/lib/radicaster/actions.ts
+++ b/web/lib/radicaster/actions.ts
@@ -29,6 +29,8 @@ export interface RecordingData {
   program_schedule: string[];
   execution_schedule: string[];
   imageFile?: File; // Optional for updates if not changing
+  retention_type?: "none" | "count" | "days";
+  retention_value?: number;
 }
 
 export type RecordingStatus = "healthy" | "s3_only" | "eventbridge_only" | "error";
@@ -164,7 +166,7 @@ export async function createRecording(data: RecordingData): Promise<void> {
   // 1. Generate YAML
   const executionSchedules = data.execution_schedule.map((s) => ExecutionSchedule.parse(s));
 
-  const yamlContent = yaml.dump({
+  const yamlObj: Record<string, any> = {
     id: data.id,
     title: data.title,
     station: data.station,
@@ -173,7 +175,14 @@ export async function createRecording(data: RecordingData): Promise<void> {
     duration: data.duration,
     program_schedule: data.program_schedule,
     execution_schedule: executionSchedules.map((s) => s.toYamlString()),
-  });
+  };
+
+  if (data.retention_type && data.retention_type !== "none" && data.retention_value) {
+    yamlObj.retention_type = data.retention_type;
+    yamlObj.retention_value = data.retention_value;
+  }
+
+  const yamlContent = yaml.dump(yamlObj);
 
   // 2. Upload to S3
   // Upload YAML


### PR DESCRIPTION
録音データが溜まりすぎないよう、番組ごとに保持ポリシーを設定できるようにした。
- Web UIの録音予約フォームに保持ポリシー設定（直近N回分/N日分）を追加
- 生成されるYAMLにretention_type/retention_valueフィールドを追加
- m4aアップロード時に発動するcleanup_episodes Lambdaを新規作成
- CDKスタックにcleanup_episodes Lambdaを追加

https://claude.ai/code/session_01PGnze3ZzQegBttzAszVXyM

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Adds an automated S3 deletion workflow triggered on uploads and changes infrastructure (new Lambda + S3 event source + delete permissions); misconfiguration or parsing issues could delete unintended objects.
> 
> **Overview**
> Adds per-recording retention policy support (keep last *N* episodes or last *N* days) end-to-end: the web form captures `retentionType`/`retentionValue`, the API validates and forwards `retention_type`/`retention_value`, and YAML generation persists these fields.
> 
> Introduces a new Docker-based Ruby Lambda (`cleanup_episodes`) wired into CDK to trigger on `.m4a` uploads; it loads the program’s `radicaster/{id}.yaml` from S3 and deletes older `id/data/*.m4a` objects based on the configured retention policy, with S3 read+delete grants.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f01b10df0179572f6780b373cda22b5878b318d7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->