### PR TITLE
録音一覧を整理: アートワークとタイトルのみ表示にし、削除・即時録音は編集画面の「…」メニューに移動

### DIFF
--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -2,8 +2,7 @@
 
 import { useEffect, useState } from "react";
 import Link from "next/link";
-import { Plus, CheckCircle, XCircle, AlertTriangle, Trash2 } from "lucide-react";
-import { cn } from "@/lib/utils";
+import { Plus, XCircle } from "lucide-react";
 
 interface Recording {
   id: string;
@@ -18,41 +17,6 @@ export default function RecordingsList() {
   const [recordings, setRecordings] = useState<Recording[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [triggeringId, setTriggeringId] = useState<string | null>(null);
-
-  const handleTriggerRecording = async (id: string) => {
-    if (confirm(`Are you sure you want to trigger recording for ${id} immediately?`)) {
-      setTriggeringId(id);
-      try {
-        const res = await fetch(`/api/recordings/${id}/trigger`, { method: "POST" });
-        if (!res.ok) {
-          const json = await res.json();
-          throw new Error(json.error || "Failed to trigger");
-        }
-        alert(`Recording triggered for ${id}!`);
-      } catch (err: any) {
-        alert(`Error: ${err.message}`);
-      } finally {
-        setTriggeringId(null);
-      }
-    }
-  };
-
-  const handleDeleteRecording = async (id: string) => {
-    if (confirm(`Are you sure you want to delete recording ${id}? This will remove the schedule and definition.`)) {
-      try {
-        const res = await fetch(`/api/recordings/${id}`, { method: "DELETE" });
-        if (!res.ok) {
-          const json = await res.json();
-          throw new Error(json.error || json.message || "Failed to delete");
-        }
-        // Remove from list
-        setRecordings((prev) => prev.filter((r) => r.id !== id));
-      } catch (err: any) {
-        alert(`Error: ${err.message}`);
-      }
-    }
-  };
 
   useEffect(() => {
     async function fetchRecordings() {
@@ -120,77 +84,29 @@ export default function RecordingsList() {
             <ul className="divide-y divide-gray-200">
               {recordings.map((recording) => (
                 <li key={recording.id}>
-                  <div className="px-4 py-4 sm:px-6 hover:bg-gray-50 flex items-center justify-between">
-                    <div className="flex items-center flex-1 min-w-0">
-                      <div className="flex-shrink-0 mr-4">
-                        {recording.imageUrl ? (
-                          <img
-                            src={recording.imageUrl}
-                            alt={recording.title || recording.id}
-                            className="h-32 w-32 rounded object-cover"
-                          />
-                        ) : (
-                          <div className="h-32 w-32 rounded bg-gray-200 flex items-center justify-center">
-                            {recording.status === "healthy" ? (
-                              <CheckCircle className="h-12 w-12 text-green-500" />
-                            ) : recording.status === "s3_only" ? (
-                              <div title="Missing EventBridge Rule">
-                                <AlertTriangle className="h-12 w-12 text-yellow-500" />
-                              </div>
-                            ) : (
-                              <div title="Missing S3 Definition">
-                                <AlertTriangle className="h-12 w-12 text-red-500" />
-                              </div>
-                            )}
-                          </div>
-                        )}
-                      </div>
-                      <div className="min-w-0 flex-1">
-                        <p className="text-sm font-medium text-indigo-600 truncate">{recording.title || recording.id}</p>
-                        <p className="text-sm text-gray-500 truncate">{recording.id}</p>
-                      </div>
+                  <Link
+                    href={`/recordings/${recording.id}`}
+                    className="px-4 py-4 sm:px-6 hover:bg-gray-50 flex items-center"
+                  >
+                    <div className="flex-shrink-0 mr-4">
+                      {recording.imageUrl ? (
+                        <img
+                          src={recording.imageUrl}
+                          alt={recording.title || recording.id}
+                          className="h-16 w-16 rounded object-cover"
+                        />
+                      ) : (
+                        <div className="h-16 w-16 rounded bg-gray-200 flex items-center justify-center">
+                          <span className="text-gray-400 text-xs">No Image</span>
+                        </div>
+                      )}
                     </div>
-                    <div className="ml-4 flex-shrink-0">
-                      <div className="flex flex-col items-end">
-                        {recording.schedules.map((s, i) => (
-                          <span key={i} className="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-blue-100 text-blue-800 mb-1">
-                            {s}
-                          </span>
-                        ))}
-                        <button
-                          onClick={(e) => {
-                            e.preventDefault();
-                            handleTriggerRecording(recording.id);
-                          }}
-                          disabled={triggeringId === recording.id}
-                          className={cn(
-                            "mt-2 text-xs border rounded px-2 py-1 transition-colors mr-2",
-                            triggeringId === recording.id
-                              ? "text-gray-400 border-gray-300 cursor-not-allowed"
-                              : "text-indigo-600 hover:text-indigo-900 border-indigo-600 hover:bg-indigo-50"
-                          )}
-                        >
-                          {triggeringId === recording.id ? "Triggering..." : "Record Now"}
-                        </button>
-                        <Link
-                          href={`/recordings/${recording.id}`}
-                          className="mt-2 text-xs border rounded px-2 py-1 transition-colors mr-2 text-blue-600 hover:text-blue-900 border-blue-600 hover:bg-blue-50 flex items-center"
-                        >
-                          Edit
-                        </Link>
-                        <button
-                          onClick={(e) => {
-                            e.preventDefault();
-                            handleDeleteRecording(recording.id);
-                          }}
-                          className="mt-2 text-xs border rounded px-2 py-1 transition-colors text-red-600 hover:text-red-900 border-red-600 hover:bg-red-50"
-                        >
-                          <Trash2 className="h-3 w-3 inline mr-1" />
-                          Delete
-                        </button>
-                      </div>
+                    <div className="min-w-0 flex-1">
+                      <p className="text-sm font-medium text-gray-900 truncate">
+                        {recording.title || recording.id}
+                      </p>
                     </div>
-                  </div>
+                  </Link>
                 </li>
               ))}
             </ul>

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -93,16 +93,16 @@ export default function RecordingsList() {
                         <img
                           src={recording.imageUrl}
                           alt={recording.title || recording.id}
-                          className="h-16 w-16 rounded object-cover"
+                          className="h-32 w-32 rounded object-cover"
                         />
                       ) : (
-                        <div className="h-16 w-16 rounded bg-gray-200 flex items-center justify-center">
-                          <span className="text-gray-400 text-xs">No Image</span>
+                        <div className="h-32 w-32 rounded bg-gray-200 flex items-center justify-center">
+                          <span className="text-gray-400 text-sm">No Image</span>
                         </div>
                       )}
                     </div>
                     <div className="min-w-0 flex-1">
-                      <p className="text-sm font-medium text-gray-900 truncate">
+                      <p className="text-xl font-medium text-gray-900 truncate">
                         {recording.title || recording.id}
                       </p>
                     </div>

--- a/web/app/recordings/[id]/page.tsx
+++ b/web/app/recordings/[id]/page.tsx
@@ -230,7 +230,7 @@ export default function EditRecordingPage({ params }: { params: Promise<{ id: st
             <button
               type="button"
               onClick={() => setMenuOpen(!menuOpen)}
-              className="p-2 rounded-md text-gray-400 hover:text-gray-600 hover:bg-gray-100 transition-colors"
+              className="p-2 rounded-md border border-gray-200 text-gray-500 bg-white shadow-sm hover:bg-gray-50 hover:text-gray-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 transition-all"
               aria-label="More actions"
             >
               <MoreHorizontal className="h-5 w-5" />

--- a/web/app/recordings/[id]/page.tsx
+++ b/web/app/recordings/[id]/page.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { useEffect, useState, use } from "react";
+import { useEffect, useState, use, useRef } from "react";
 import { useRouter } from "next/navigation";
 import { RecordingForm, FormValues } from "@/app/components/RecordingForm";
+import { MoreHorizontal, Trash2, Mic } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 interface ScheduleYaml {
@@ -38,31 +39,7 @@ function calculateOffset(programTime: any, executionTime: any): number {
   const progTotal = programTime.hour * 60 + programTime.minute;
   const execTotal = executionTime.hour * 60 + executionTime.minute + (dayDiff * 24 * 60);
 
-  // execution = program + duration + offset
-  // But wait, execution time in YAML usually marks the START of recording?
-  // Let's check Rec-Radiko.
-  // Actually, in `RecordingForm`, `executionTime` calculation is:
-  // totalMinutesVal = totalCurrentMinutes + (duration || 0) + (offset || 0);
-  // So Execution Time is the time when recording ENDS? Or STARTS?
-  // Rec-Radiko usually takes "start time" and "duration".
-  // If `execution_schedule` is passed to EventBridge cron, and the target is `rec-radiko`,
-  // then `rec-radiko` is triggered at `execution_schedule`.
-  // If `rec-radiko` starts recording immediately, then `execution_schedule` is the recording START time.
-
-  // In `new/page.tsx`:
-  // calculateExecutionTime adds duration!
-  // `totalMinutesVal = totalCurrentMinutes + (duration || 0) + (offset || 0)`
-  // This implies `execution_schedule` = BroadCastStart + Duration + Offset.
-  // This means the recording starts AFTER the program ends?
-  // Yes, usually for time-free recording, you record after it's done.
-  // Radiko Time Free becomes available after broadcast.
-  // So Offset is "how many minutes after broadcast ENDs do we start recording".
-
-  // So: ExecutionTime = ProgramStart + Duration + Offset.
-  // Thus: Offset = ExecutionTime - (ProgramStart + Duration).
-
-  // However, I don't have Duration passed into this function yet.
-  return execTotal - progTotal; // This returns (Duration + Offset)
+  return execTotal - progTotal;
 }
 
 export default function EditRecordingPage({ params }: { params: Promise<{ id: string }> }) {
@@ -72,6 +49,55 @@ export default function EditRecordingPage({ params }: { params: Promise<{ id: st
   const [error, setError] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [result, setResult] = useState<{ success: boolean; message: string } | null>(null);
+  const [menuOpen, setMenuOpen] = useState(false);
+  const [triggeringId, setTriggeringId] = useState(false);
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  // Close menu when clicking outside
+  useEffect(() => {
+    function handleClickOutside(event: MouseEvent) {
+      if (menuRef.current && !menuRef.current.contains(event.target as Node)) {
+        setMenuOpen(false);
+      }
+    }
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, []);
+
+  const handleTriggerRecording = async () => {
+    if (confirm(`Record "${id}" immediately?`)) {
+      setMenuOpen(false);
+      setTriggeringId(true);
+      try {
+        const res = await fetch(`/api/recordings/${id}/trigger`, { method: "POST" });
+        if (!res.ok) {
+          const json = await res.json();
+          throw new Error(json.error || "Failed to trigger");
+        }
+        alert(`Recording triggered for ${id}!`);
+      } catch (err: any) {
+        alert(`Error: ${err.message}`);
+      } finally {
+        setTriggeringId(false);
+      }
+    }
+  };
+
+  const handleDeleteRecording = async () => {
+    if (confirm(`Delete "${id}"? This will remove the schedule and definition.`)) {
+      setMenuOpen(false);
+      try {
+        const res = await fetch(`/api/recordings/${id}`, { method: "DELETE" });
+        if (!res.ok) {
+          const json = await res.json();
+          throw new Error(json.error || json.message || "Failed to delete");
+        }
+        router.push("/");
+      } catch (err: any) {
+        alert(`Error: ${err.message}`);
+      }
+    }
+  };
 
   useEffect(() => {
     async function fetchData() {
@@ -141,14 +167,6 @@ export default function EditRecordingPage({ params }: { params: Promise<{ id: st
       program_schedule: formData.schedules.map(s => `${s.startDay} ${s.startHour}:${s.startMinute}`),
       duration: formData.schedules[0]?.durationMinutes,
       execution_schedule: formData.schedules.map(s => {
-        // calculateExecutionTime is internal to component or need export
-        // I need to copy or import calculateExecutionTime logic.
-        // Since I haven't exported it from RecordingForm (it was inside the file but outside component),
-        // I will reimplement logic or assume form calculates it?
-        // No, form data has inputs. Backend expects `execution_schedule`.
-        // I reused logic in `new/page.tsx` for submission. 
-        // I should do same here.
-
         const DAYS = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
         const dayIndex = DAYS.indexOf(s.startDay);
         const totalCurrentMinutes = parseInt(s.startHour || "0") * 60 + parseInt(s.startMinute || "0");
@@ -201,11 +219,46 @@ export default function EditRecordingPage({ params }: { params: Promise<{ id: st
   return (
     <div className="min-h-screen bg-gray-50 py-12 px-4 sm:px-6 lg:px-8 text-black">
       <div className="max-w-2xl mx-auto bg-white p-8 rounded-lg shadow">
-        <div className="mb-8">
-          <h1 className="text-2xl font-bold text-gray-900">Edit Recording</h1>
-          <p className="mt-2 text-sm text-gray-600">
-            Edit recording schedule. Changing details will delete and recreate the resources.
-          </p>
+        <div className="flex items-start justify-between mb-8">
+          <div>
+            <h1 className="text-2xl font-bold text-gray-900">Edit Recording</h1>
+            <p className="mt-2 text-sm text-gray-600">
+              Edit recording schedule. Changing details will delete and recreate the resources.
+            </p>
+          </div>
+          <div className="relative" ref={menuRef}>
+            <button
+              type="button"
+              onClick={() => setMenuOpen(!menuOpen)}
+              className="p-2 rounded-md text-gray-400 hover:text-gray-600 hover:bg-gray-100 transition-colors"
+              aria-label="More actions"
+            >
+              <MoreHorizontal className="h-5 w-5" />
+            </button>
+            {menuOpen && (
+              <div className="absolute right-0 mt-1 w-48 bg-white rounded-md shadow-lg ring-1 ring-black ring-opacity-5 z-10">
+                <div className="py-1">
+                  <button
+                    type="button"
+                    onClick={handleTriggerRecording}
+                    disabled={triggeringId}
+                    className="w-full text-left px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 flex items-center gap-2 disabled:opacity-50"
+                  >
+                    <Mic className="h-4 w-4" />
+                    {triggeringId ? "Triggering..." : "Record Now"}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={handleDeleteRecording}
+                    className="w-full text-left px-4 py-2 text-sm text-red-600 hover:bg-red-50 flex items-center gap-2"
+                  >
+                    <Trash2 className="h-4 w-4" />
+                    Delete
+                  </button>
+                </div>
+              </div>
+            )}
+          </div>
         </div>
 
         {result && (


### PR DESCRIPTION
https://claude.ai/code/session_016a8fRGyvGCsAbbQUSWAwQp

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only refactor that rehomes existing trigger/delete flows without changing backend APIs or data handling; main risk is minor UX/regression around menu interactions and navigation.
> 
> **Overview**
> Simplifies the recordings list UI to show only artwork (or a `No Image` placeholder) and title, and makes each row a single link to the recording detail page.
> 
> Moves per-recording actions off the list: immediate trigger and delete are now available from a new `...` dropdown on the edit page, including outside-click-to-close behavior and disabled state while triggering; successful delete navigates back to `/`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6802e8a1ba3240c2c92fe1ec282921d9314adf90. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->